### PR TITLE
fix: include bootstrap-mods in AthleticAPP.scss

### DIFF
--- a/src/Athletic.APP.scss
+++ b/src/Athletic.APP.scss
@@ -71,6 +71,6 @@
 @import "table";
 // @import "page-header";
 @import "columns";
-// @import "bootstrap-mods";
+@import "bootstrap-mods";
 @import "navigation";
 // @import "compatibility";


### PR DESCRIPTION
Some page sizing mods are included here that we use on the web but don't work the same on the app.